### PR TITLE
Increase button size to match other devTool buttons in the industry

### DIFF
--- a/react/lib/assets/ButtonStyles.tsx
+++ b/react/lib/assets/ButtonStyles.tsx
@@ -10,14 +10,13 @@ export default function ButtonStyles() {
         justify-content: space-evenly;
         align-items: center;
         flex-shrink: 0;
-        max-width: 74px;
-        max-height: 24px;
-        width: 74px;
-        height: 24px;
+        width: 92px;
+        height: 35px;
         font-weight: 700;
         color: #fff;
-        border-radius: 4px;
+        border-radius: 3px;
         cursor: pointer;
+        overflow: hidden;
       }
 
       .doppler-gradient {
@@ -30,7 +29,6 @@ export default function ButtonStyles() {
         height: 100%;
         opacity: 1;
         z-index: -2;
-        border-radius: 4px;
         background: linear-gradient(216.71deg, #4F80FF 6.72%, #7A4BFF 91.2%);
         transition: all .2s ease-in-out;
       }
@@ -40,12 +38,11 @@ export default function ButtonStyles() {
         top: 0;
         left: 0;
         opacity: 0;
-        min-width:100%;
-        min-height:100%;
+        min-width: 100%;
+        min-height: 100%;
         width: 100%;
         height: 100%;
         z-index: -1;
-        border-radius: 4px;
         background: linear-gradient(216.71deg, #2375F3 6.72%, #7C1FF4 91.2%);
         transition: all .2s ease-in-out;
       }
@@ -56,6 +53,7 @@ export default function ButtonStyles() {
 
       .import-svg {
         margin-top: 2px;
+        height: 13px;
       }
     `}
     </style>


### PR DESCRIPTION
Our button is `74 x 23px` which feels pretty small. Looking at other popular devTool buttons, Heroku is `147 x 32px` and Vercel is `104 x 36px`.

## Vercel (`147 x 32px`)
<img width="733" alt="Screen Shot 2022-08-21 at 2 38 33 PM" src="https://user-images.githubusercontent.com/1920007/185812367-e8f598aa-5f20-4a11-a425-6940724b2b45.png">

## Heroku (`104 x 36px`)
<img width="713" alt="Screen Shot 2022-08-21 at 2 38 27 PM" src="https://user-images.githubusercontent.com/1920007/185812370-f6b791d6-9c19-48c9-b77d-d642d9175506.png">


## Import Button: Before (`74 x 23px`)
Preview: https://import-ted4792.preview.doppler.team
<img width="400" alt="Screen Shot 2022-08-21 at 2 47 56 PM" src="https://user-images.githubusercontent.com/1920007/185812249-13dc7752-08d4-423a-8906-54503f65c7cc.png">

## Import Button: After (`92 x 35px`)
Preview: https://import-ted4573.preview.doppler.team
<img width="414" alt="Screen Shot 2022-08-22 at 1 16 04 AM" src="https://user-images.githubusercontent.com/1920007/185873298-4ac6b6c1-ae43-475b-b511-7ea66b18baf3.png">

