### PR TITLE
Use bash to trigger post-build.sh

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -10,10 +10,10 @@
   "license": "Apache-2.0",
   "scripts": {
     "clean": "rm -rf ./dist tsconfig.tsbuildinfo",
-    "build:watch": "tsc-watch --preserveWatchOutput --onSuccess 'doppler run --config dev -- sh ./post-build.sh'",
-    "build:staging": "tsc && doppler run --config stg -- sh ./post-build.sh",
-    "build:github-action": "tsc && sh ./post-build.sh",
-    "build": "tsc && doppler run -- sh ./post-build.sh"
+    "build:watch": "tsc-watch --preserveWatchOutput --onSuccess 'doppler run --config dev -- bash ./post-build.sh'",
+    "build:staging": "tsc && doppler run --config stg -- bash ./post-build.sh",
+    "build:github-action": "tsc && bash ./post-build.sh",
+    "build": "tsc && doppler run -- bash ./post-build.sh"
   },
   "dependencies": {
     "tweetnacl-sealedbox-js": "^1.2.0",


### PR DESCRIPTION
The `sed` command we're using in `post-build.sh` requires bash (using sh throws a ["bad substitution"](https://github.com/DopplerHQ/universal-import/runs/7955536967?check_suite_focus=true) error)