### PR TITLE
Fix U.Import App.tsx missing React Import

### DIFF
--- a/react-example/src/App.tsx
+++ b/react-example/src/App.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import DopplerImportButton from "@dopplerhq/universal-import-react";
 import { nanoid } from "nanoid";
 


### PR DESCRIPTION
## Description

This PR clears the  `npm run docker`  error which in turns will allow Release Environments to work

## Error
```
error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.
```
This is because we moved to React 16 which means we need to explicitly import React