### PR TITLE
ENG-5476: Release v1.0.0 for Universal Import packages

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dopplerhq/universal-import-core",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
     },
     "core": {
       "name": "@dopplerhq/universal-import-core",
-      "version": "0.0.13",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tweetnacl-sealedbox-js": "^1.2.0",
@@ -9081,10 +9081,10 @@
     },
     "react": {
       "name": "@dopplerhq/universal-import-react",
-      "version": "0.0.13",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dopplerhq/universal-import-core": "*"
+        "@dopplerhq/universal-import-core": "1.0.0"
       },
       "devDependencies": {
         "@types/node": "^18.0.2",
@@ -9103,7 +9103,7 @@
     },
     "react-example": {
       "name": "@dopplerhq/react-example",
-      "version": "0.0.13",
+      "version": "1.0.0",
       "dependencies": {
         "@dopplerhq/universal-import-core": "file:../core",
         "@dopplerhq/universal-import-react": "file:../react",
@@ -9755,7 +9755,7 @@
     "@dopplerhq/universal-import-react": {
       "version": "file:react",
       "requires": {
-        "@dopplerhq/universal-import-core": "*",
+        "@dopplerhq/universal-import-core": "1.0.0",
         "@types/node": "^18.0.2",
         "@types/react": "^16.8.0",
         "@types/react-dom": "^16.8.0",

--- a/react-example/package.json
+++ b/react-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dopplerhq/react-example",
   "private": true,
-  "version": "0.0.13",
+  "version": "1.0.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dopplerhq/universal-import-react",
-  "version": "0.0.13",
+  "version": "1.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     "build": "tsc && doppler run -- vite build"
   },
   "dependencies": {
-    "@dopplerhq/universal-import-core": "*"
+    "@dopplerhq/universal-import-core": "1.0.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## Description

This officially releases `1.0.0` for our Universal Import packages. It also fixes the version for the `core` dependency inside of the `react` package to the version it needs instead of the `"*"` wildcard.

This was thoroughly tested, the `react` package (when installed) will also download the `core` package specified inside the `react` `package.json` `dependency`