### PR TITLE
ENG-4943: validate secret names

### DIFF
--- a/core/lib/index.ts
+++ b/core/lib/index.ts
@@ -12,8 +12,18 @@ export async function fetchKeyInfo() {
   return await encryption.fetchKeyInfo(DOPPLER_UNIVERSAL_KEY_URL);
 }
 
+const secretNameRegex = /^[A-Z_]+[A-Z0-9_]*$/;
+export function validateSecretName(secretName: string) {
+  if (!secretNameRegex.test(secretName)) {
+    console.error(
+      `Invalid secret name: ${secretName}. Secret names must be uppercased and may only contain letters, numbers and underscores`,
+    );
+  }
+}
+
 export async function trigger(props: DopplerImport) {
   const { secretName, secretValue } = props;
+  validateSecretName(secretName);
   const resolvedKey = await fetchKeyInfo();
   const secrets = [{ name: secretName, value: secretValue }];
   const payload = utils.createPayload(secrets);

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dopplerhq/universal-import-core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
     },
     "core": {
       "name": "@dopplerhq/universal-import-core",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "tweetnacl-sealedbox-js": "^1.2.0",
@@ -9081,10 +9081,10 @@
     },
     "react": {
       "name": "@dopplerhq/universal-import-react",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dopplerhq/universal-import-core": "1.0.1"
+        "@dopplerhq/universal-import-core": "1.0.2"
       },
       "devDependencies": {
         "@types/node": "^18.0.2",
@@ -9103,7 +9103,7 @@
     },
     "react-example": {
       "name": "@dopplerhq/react-example",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
         "@dopplerhq/universal-import-core": "file:../core",
         "@dopplerhq/universal-import-react": "file:../react",
@@ -9755,7 +9755,7 @@
     "@dopplerhq/universal-import-react": {
       "version": "file:react",
       "requires": {
-        "@dopplerhq/universal-import-core": "1.0.1",
+        "@dopplerhq/universal-import-core": "1.0.2",
         "@types/node": "^18.0.2",
         "@types/react": "^16.8.0",
         "@types/react-dom": "^16.8.0",

--- a/react-example/package.json
+++ b/react-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dopplerhq/react-example",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",

--- a/react/lib/DopplerImportButton.tsx
+++ b/react/lib/DopplerImportButton.tsx
@@ -1,4 +1,4 @@
-import { DopplerImport, trigger, fetchKeyInfo } from "@dopplerhq/universal-import-core";
+import { DopplerImport, trigger, fetchKeyInfo, validateSecretName } from "@dopplerhq/universal-import-core";
 import Logo from "./assets/Logo";
 import ImportSVG from "./assets/ImportText";
 import ButtonStyles from "./assets/ButtonStyles";
@@ -10,6 +10,8 @@ interface DopplerImportButtonProps extends DopplerImport {
 }
 
 export function DopplerImportButton(props: DopplerImportButtonProps) {
+  validateSecretName(props.secretName);
+
   async function onClick() {
     await trigger(props);
   }

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dopplerhq/universal-import-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
     "build": "tsc && doppler run -- vite build"
   },
   "dependencies": {
-    "@dopplerhq/universal-import-core": "1.0.1"
+    "@dopplerhq/universal-import-core": "1.0.2"
   },
   "peerDependencies": {
     "react": ">=16.8.0",


### PR DESCRIPTION
## Description

This PR adds secret name validation to both the `universal-import-core` exposed `trigger` function as well as when the `universal-import-react` package through the`<DopplerImportButton .../>` component when it is mounted.

This will allows integrators to see an error message in their browser developer console if their secret names do not adhere to the Doppler secret naming convention.
