### PR TITLE
Update npm audit to scan workspaces

### DIFF
--- a/.github/workflows/scanners.yaml
+++ b/.github/workflows/scanners.yaml
@@ -15,4 +15,4 @@ jobs:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
       - name: npm audit
-        run: npm audit
+        run: npm audit --workspaces --include-workspace-root


### PR DESCRIPTION
This PR adds the `--workspaces --include-workspace-root` flags to the npm audit command, which scans internal npm workspaces for `npm audit` issues.