### PR TITLE
Update vite to address Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8739,9 +8739,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.14.27",
@@ -9093,7 +9093,7 @@
         "@vitejs/plugin-react": "^1.3.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "typescript": "^4.7.4",
-        "vite": "^2.9.9",
+        "vite": "^2.9.16",
         "vite-plugin-dts": "^1.3.1"
       },
       "peerDependencies": {
@@ -9117,7 +9117,7 @@
         "@vitejs/plugin-react": "^1.3.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "typescript": "^4.7.4",
-        "vite": "^2.9.9"
+        "vite": "^2.9.16"
       }
     },
     "react-example/node_modules/@dopplerhq/universal-import-react": {
@@ -9674,7 +9674,7 @@
         "react-dom": "16.8.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "typescript": "^4.7.4",
-        "vite": "^2.9.9"
+        "vite": "^2.9.16"
       },
       "dependencies": {
         "@dopplerhq/universal-import-react": {
@@ -9762,7 +9762,7 @@
         "@vitejs/plugin-react": "^1.3.0",
         "rollup-plugin-visualizer": "^5.6.0",
         "typescript": "^4.7.4",
-        "vite": "^2.9.9",
+        "vite": "^2.9.16",
         "vite-plugin-dts": "^1.3.1"
       },
       "dependencies": {
@@ -15677,9 +15677,9 @@
       "dev": true
     },
     "vite": {
-      "version": "2.9.15",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.15.tgz",
-      "integrity": "sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==",
+      "version": "2.9.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-2.9.16.tgz",
+      "integrity": "sha512-X+6q8KPyeuBvTQV8AVSnKDvXoBMnTx8zxh54sOwmmuOdxkjMmEJXH2UEchA+vTMps1xw9vL64uwJOWryULg7nA==",
       "dev": true,
       "requires": {
         "esbuild": "^0.14.27",

--- a/react-example/package.json
+++ b/react-example/package.json
@@ -20,6 +20,6 @@
     "@vitejs/plugin-react": "^1.3.0",
     "rollup-plugin-visualizer": "^5.6.0",
     "typescript": "^4.7.4",
-    "vite": "^2.9.9"
+    "vite": "^2.9.16"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -31,7 +31,7 @@
     "@vitejs/plugin-react": "^1.3.0",
     "rollup-plugin-visualizer": "^5.6.0",
     "typescript": "^4.7.4",
-    "vite": "^2.9.9",
+    "vite": "^2.9.16",
     "vite-plugin-dts": "^1.3.1"
   }
 }


### PR DESCRIPTION
Preview deployment is not impacted by the vulnerability as it uses `vite preview`, not the dev server.

See advisory for details:
https://github.com/advisories/GHSA-353f-5xf4-qw67

Closes ENG-6349